### PR TITLE
Fix separation of query parts by '&' rather than ';'

### DIFF
--- a/pkcs11uri.go
+++ b/pkcs11uri.go
@@ -309,7 +309,11 @@ func formatAttributes(attrMap map[string]string, ispath bool) string {
 			}
 		}
 		if len(res) > 0 {
-			res += ";"
+			if ispath {
+				res += ";"
+			} else {
+				res += "&"
+			}
 		}
 		res += key + "=" + value
 	}


### PR DESCRIPTION
Fix the separation of query parts by '&'. The path parts are separated
by ';'.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>