### PR TITLE
Add SetAllowAnyModule and switch to deny-all policy

### DIFF
--- a/pkcs11uri.go
+++ b/pkcs11uri.go
@@ -38,6 +38,8 @@ type Pkcs11URI struct {
 	moduleDirectories []string
 	// file paths of allowed pkcs11 modules
 	allowedModulePaths []string
+	// whether any module is allowed to be loaded
+	allowAnyModule bool
 	// A map of environment variables needed by the pkcs11 module using this URI.
 	// This map is not needed by this implementation but is there for convenience.
 	env map[string]string
@@ -355,16 +357,20 @@ func (uri *Pkcs11URI) GetModuleDirectories() []string {
 	return uri.moduleDirectories
 }
 
-// SetAllowedModulePaths sets allowed module paths to restrict access to modules. By
-// default no filtering is done.
+// SetAllowedModulePaths sets allowed module paths to restrict access to modules.
 // Directory entries must end with a '/', all other ones are assumed to be file entries.
 // Allowed modules are filtered by string matching.
 func (uri *Pkcs11URI) SetAllowedModulePaths(allowedModulePaths []string) {
 	uri.allowedModulePaths = allowedModulePaths
 }
 
+// SetAllowAnyModule allows any module to be loaded; by default this is not allowed
+func (uri *Pkcs11URI) SetAllowAnyModule(allowAnyModule bool) {
+	uri.allowAnyModule = allowAnyModule
+}
+
 func (uri *Pkcs11URI) isAllowedPath(path string, allowedPaths []string) bool {
-	if len(allowedPaths) == 0 {
+	if uri.allowAnyModule {
 		return true
 	}
 	for _, allowedPath := range allowedPaths {

--- a/pkcs11uri_test.go
+++ b/pkcs11uri_test.go
@@ -297,6 +297,7 @@ func TestValidateEscapedAttrs(t *testing.T) {
 func TestGetModule(t *testing.T) {
 	uri := New()
 	uri.SetModuleDirectories(modulePaths)
+	uri.SetAllowAnyModule(true)
 
 	uristring := "pkcs11:?module-name=softhsm2"
 	err := uri.Parse(uristring)

--- a/pkcs11uri_test.go
+++ b/pkcs11uri_test.go
@@ -24,8 +24,9 @@ import (
 )
 
 var modulePaths = []string{
-	"/usr/lib64/pkcs11/", // Fedora
-	"/usr/lib/softhsm/",  // Ubuntu
+	"/usr/lib64/pkcs11/", // Fedora, RHEL, openSUSE
+	"/usr/lib/pkcs11/",   // Fedora 32 bit, ArchLinux
+	"/usr/lib/softhsm/",  // Ubuntu, Debian, Alpine
 }
 
 func TestParse1(t *testing.T) {


### PR DESCRIPTION
Implement SetAllowedAnyModule to set whether any module may be loaded
or none. The default is now deny-all.
